### PR TITLE
Removing forbidden functions

### DIFF
--- a/sdk/core/azure-core/src/datetime.cpp
+++ b/sdk/core/azure-core/src/datetime.cpp
@@ -26,7 +26,8 @@ DateTime GetSystemClockEpoch()
 // instead.
 #pragma warning(disable : 4996)
 #endif
-  auto const systemClockEpochUtcStructTm = std::gmtime(&systemClockEpochTimeT);
+  struct tm tmpBufSystemClockEpochUtcStructTm;
+  auto const systemClockEpochUtcStructTm = gmtime_r(&systemClockEpochTimeT, &tmpBufSystemClockEpochUtcStructTm);
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif


### PR DESCRIPTION
A couple of tests failed in PR https://github.com/ClickHouse/ClickHouse/pull/31505 because of the `gmtime` function presence in the Azure SDK code, which is forbidden in ClickHouse (see file https://github.com/ClickHouse/ClickHouse/blob/master/base/harmful/harmful.c). This PR is a fix for that.

I have also noticed that another forbidden function, `localeconv` is present in the SDK code, in sdk/core/azure-core/inc/azure/core/internal/json/json.hpp. I think it might require some kind of a fix too.

Furthermore, `strtok` and `unsetenv` are used in some tests.