### PR TITLE
Remove usage of `std::regex`

### DIFF
--- a/sdk/core/azure-core/src/http/http_sanitizer.cpp
+++ b/sdk/core/azure-core/src/http/http_sanitizer.cpp
@@ -3,7 +3,6 @@
 
 #include "azure/core/internal/http/http_sanitizer.hpp"
 #include "azure/core/url.hpp"
-#include <regex>
 #include <sstream>
 
 namespace {


### PR DESCRIPTION
Removes `<regex>` from azure, see https://github.com/ClickHouse/ClickHouse/pull/58458 and https://github.com/ClickHouse/llvm-project/pull/38