### PR TITLE
Revert "Revert "add clickhouse specific options to azure client""

### DIFF
--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_container_client.hpp
@@ -284,6 +284,10 @@ namespace Azure { namespace Storage { namespace Blobs {
         const UploadBlockBlobOptions& options = UploadBlockBlobOptions(),
         const Azure::Core::Context& context = Azure::Core::Context()) const;
 
+
+    const ClickhouseClientOptions & GetClickhouseOptions() const;
+    void SetClickhouseOptions(ClickhouseClientOptions options);
+
   private:
     Azure::Core::Url m_blobContainerUrl;
     std::shared_ptr<Azure::Core::Http::_internal::HttpPipeline> m_pipeline;
@@ -300,6 +304,8 @@ namespace Azure { namespace Storage { namespace Blobs {
           m_encryptionScope(std::move(encryptionScope))
     {
     }
+
+    ClickhouseClientOptions m_clickhouseOptions;
 
     friend class BlobServiceClient;
     friend class BlobLeaseClient;

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -164,6 +164,8 @@ namespace Azure { namespace Storage { namespace Blobs {
      * API version used by this client.
      */
     std::string ApiVersion = _detail::ApiVersion;
+
+    ClickhouseClientOptions ClickhouseOptions = {};
   };
 
   /**

--- a/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
+++ b/sdk/storage/azure-storage-blobs/inc/azure/storage/blobs/blob_options.hpp
@@ -129,6 +129,14 @@ namespace Azure { namespace Storage { namespace Blobs {
   };
 
   /**
+   * @brief Wrapper for a clickhouse speciefic options for the Azure client.
+   */
+  struct ClickhouseClientOptions
+  {
+    bool IsClientForDisk = false;
+  };
+
+  /**
    * @brief Client options used to initialize all kinds of blob clients.
    */
   struct BlobClientOptions final : Azure::Core::_internal::ClientOptions

--- a/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
+++ b/sdk/storage/azure-storage-blobs/src/blob_container_client.cpp
@@ -111,6 +111,8 @@ namespace Azure { namespace Storage { namespace Blobs {
         _detail::PackageVersion::ToString(),
         std::move(perRetryPolicies),
         std::move(perOperationPolicies));
+
+    m_clickhouseOptions = options.ClickhouseOptions;
   }
 
   BlobClient BlobContainerClient::GetBlobClient(const std::string& blobName) const
@@ -386,6 +388,16 @@ namespace Azure { namespace Storage { namespace Blobs {
     auto response = blockBlobClient.Upload(content, options, context);
     return Azure::Response<BlockBlobClient>(
         std::move(blockBlobClient), std::move(response.RawResponse));
+  }
+
+  const ClickhouseClientOptions & BlobContainerClient::GetClickhouseOptions() const
+  {
+    return m_clickhouseOptions;
+  }
+
+  void BlobContainerClient::SetClickhouseOptions(ClickhouseClientOptions options)
+  {
+    m_clickhouseOptions = std::move(options);
   }
 
 }}} // namespace Azure::Storage::Blobs


### PR DESCRIPTION
Reverts ClickHouse/azure-sdk-for-cpp#22
This is second attempt to do https://github.com/ClickHouse/azure-sdk-for-cpp/pull/20
Previously one line of code has been missed. 

It is convinient to have some option inside client.
The first such options is IsClientForDisk.
When Azure client is created we definitely know what kind of storage is the source. That define how we make statistics and loging.