### PR TITLE
Do not call localeconv() in Azure JSON library

### DIFF
--- a/sdk/core/azure-core/inc/azure/core/internal/json/json.hpp
+++ b/sdk/core/azure-core/inc/azure/core/internal/json/json.hpp
@@ -11486,9 +11486,10 @@ namespace Azure { namespace Core { namespace Json { namespace _internal { namesp
     _azure_JSON_HEDLEY_PURE
     static char get_decimal_point() noexcept
     {
-      const auto* loc = localeconv();
-      _azure_JSON_ASSERT(loc != nullptr);
-      return (loc->decimal_point == nullptr) ? '.' : *(loc->decimal_point);
+      // ClickHouse always uses the C locale where the decimal point is '.'.
+      // localeconv() is non-thread-safe and is prohibited by ClickHouse's
+      // harmful function list in debug/sanitizer builds.
+      return '.';
     }
 
     /////////////////////
@@ -22257,15 +22258,12 @@ namespace Azure { namespace Core { namespace Json { namespace _internal { namesp
         output_adapter_t<char> s,
         const char ichar,
         error_handler_t error_handler_ = error_handler_t::strict)
-        : o(std::move(s)), loc(std::localeconv()),
-          thousands_sep(
-              loc->thousands_sep == nullptr
-                  ? '\0'
-                  : std::char_traits<char>::to_char_type(*(loc->thousands_sep))),
-          decimal_point(
-              loc->decimal_point == nullptr
-                  ? '\0'
-                  : std::char_traits<char>::to_char_type(*(loc->decimal_point))),
+        : o(std::move(s)), loc(nullptr),
+          thousands_sep('\0'),
+          decimal_point('.'),
+          // ClickHouse always uses the C locale: thousands_sep='\0', decimal_point='.'.
+          // localeconv() is non-thread-safe and is prohibited by ClickHouse's
+          // harmful function list in debug/sanitizer builds.
           indent_char(ichar), indent_string(512, indent_char), error_handler(error_handler_)
     {
     }


### PR DESCRIPTION
The Azure SDK's bundled JSON library (`json.hpp`) calls `localeconv()` in two places:

1. `lexer::get_decimal_point()` — called during JSON parsing
2. `serializer` constructor — to initialize `thousands_sep` and `decimal_point`

`localeconv` is non-thread-safe and is trapped by ClickHouse's harmful function list in debug/sanitizer builds, causing a fatal `SIGILL` when the Azure SDK parses a JSON token response (e.g. during `ClientSecretCredential::GetToken`). This made querying DeltaLake/Iceberg tables on Azure (e.g. OneLake) crash the server in debug/ASan builds.

ClickHouse always uses the C locale, so the decimal point is always `'.'` and the thousands separator is always `'\0'`. Both call sites are replaced with these hardcoded values.

Fixes https://github.com/ClickHouse/clickhouse-private/issues/52215